### PR TITLE
Module feature and context screen control additions

### DIFF
--- a/Bud/Bud.csproj
+++ b/Bud/Bud.csproj
@@ -44,6 +44,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Context.cs" />
+    <Compile Include="Modules\Module.cs" />
+    <Compile Include="Modules\Navigator\Navigator.cs" />
+    <Compile Include="Modules\Navigator\NavigatorMainScreen.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Screens\MainScreen.cs" />

--- a/Bud/Context.cs
+++ b/Bud/Context.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Bud.Modules;
 
 namespace Bud
 {
@@ -17,16 +18,22 @@ namespace Bud
         public static ConsoleColor COLOR_FOREGROUND { get; set; }
         public static ConsoleColor COLOR_SELECTED { get; set; }
         public static ConsoleColor COLOR_DEBUG { get; set; }
+        public static ConsoleColor COLOR_ERROR { get; set; }
 
         public static string NAME { get; set; }
 
         public static bool DEBUG { get; set; }
+        public static bool ERROR { get; set; }
 
         public static bool isCursorVisible() { return Console.CursorVisible; }
         public static void setCursorVisible(bool visible) {
             Console.CursorVisible = visible;
         }
 
+        //contains all previous screens. current screen is available through CURRENT_SCREEN
+        private static Stack<Screen> screenStack;
+
+        //initialize the program. Must run first.
         public static void loadContext()
         {
             NAME = "Alex";
@@ -35,10 +42,13 @@ namespace Bud
             COLOR_FOREGROUND = ConsoleColor.White;
             COLOR_SELECTED = ConsoleColor.Cyan;
             COLOR_DEBUG = ConsoleColor.Yellow;
+            COLOR_ERROR = ConsoleColor.Red;
+            screenStack = new Stack<Screen>();
             CURRENT_SCREEN = new MainScreen();
             DEBUG = true;
         }
 
+        //Print a debug message at the current cursor location if the DEBUG flag is set
         public static void debug(string message)
         {
             if (DEBUG)
@@ -48,6 +58,52 @@ namespace Bud
                 Console.ForegroundColor = COLOR_FOREGROUND;
             }
         }
+
+        //Print an error message at the current cursor location if the ERROR flag is set 
+        public static void error(string message, Exception e = null)
+        {
+            if (ERROR)
+            {
+                Console.ForegroundColor = COLOR_DEBUG;
+                Console.WriteLine(message);
+                if (e != null) Console.WriteLine(e.Message);
+                Console.ForegroundColor = COLOR_FOREGROUND;
+            }
+        }
+
+        //Transition to a new screen within a module.
+        public static void transition(Screen toScreen)
+        {
+            //push the origin screen onto stack
+            screenStack.Push(CURRENT_SCREEN);
+            CURRENT_SCREEN = toScreen;            
+            //CURRENT_SCREEN.render();
+        }
+
+        //Move back to the previous screen and cleanup the current screen.
+        public static void backScreen()
+        {
+            try
+            {
+                CURRENT_SCREEN.cleanup();
+                CURRENT_SCREEN = screenStack.Pop();
+                //CURRENT_SCREEN.render();
+            }
+            catch (InvalidOperationException e)
+            {
+                error("ERROR: No screen to go back to.", e);
+            }
+        }
+
+        //load a module and transition to module's main screen
+        public static void loadModule(Module m)
+        {
+            m.init();
+            screenStack.Push(CURRENT_SCREEN);
+            CURRENT_SCREEN = m.getScreen();
+        }
+
+        //todo: unload module / cleanup
 
     }
 }

--- a/Bud/Modules/Module.cs
+++ b/Bud/Modules/Module.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Bud.Screens;
+
+namespace Bud.Modules
+{
+    //The idea of a Module is a potentially self contained collection of screens and logic, 
+    //with the Module class itself maintaining any specific context info it would require.
+    interface Module
+    {
+        //Called before loadScreen to do basic setup.
+        void init();
+        //Load a screen. Module logic handles what screen to show.
+        Screen getScreen();
+        //Render current screen.
+        void render();
+    }
+}

--- a/Bud/Modules/Navigator/Navigator.cs
+++ b/Bud/Modules/Navigator/Navigator.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Bud.Screens;
+
+namespace Bud.Modules.Navigator
+{
+    class NavigatorModule : Module
+    {
+        private static string SCREEN_MAIN = "main";
+
+        private Dictionary<string, Screen> screens = new Dictionary<string, Screen>();
+        private Screen currentScreen;
+
+        public void init()
+        {
+            screens.Add(SCREEN_MAIN, new NavigatorMainScreen());
+            currentScreen = screens[SCREEN_MAIN];
+        }
+
+        public Screen getScreen()
+        {
+            return currentScreen;
+        }
+
+        public void render()
+        {
+            currentScreen.render();
+        }
+    }
+}

--- a/Bud/Modules/Navigator/NavigatorMainScreen.cs
+++ b/Bud/Modules/Navigator/NavigatorMainScreen.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Bud.Screens;
+using Bud.Widgets;
+
+namespace Bud.Modules.Navigator
+{
+    class NavigatorMainScreen : Screen
+    {
+        MenuList menu;
+        List<string> optionList;
+
+        public NavigatorMainScreen(Screen returnScreen = null)
+        {
+            optionList = new List<string>() { "My Computer", "Sample Bookmark 1", "Sample Bookmark 2" };
+            menu = new MenuList();
+            menu.addOptionList(optionList);
+        }
+
+        public void render()
+        {
+            Console.Clear();
+            Console.WriteLine("*** NAVIGATOR ***\n");
+            Console.WriteLine("Launch from:");
+            menu.render();
+        }
+
+        public void processInput(ConsoleKeyInfo key)
+        {
+            switch (key.Key)
+            {
+                case ConsoleKey.B:
+                    Context.backScreen();
+                    break;
+                case ConsoleKey.UpArrow:
+                case ConsoleKey.DownArrow:
+                    menu.processInput(key);
+                    break;
+            }
+        }
+
+        public void cleanup() { }
+    }
+}

--- a/Bud/Program.cs
+++ b/Bud/Program.cs
@@ -19,6 +19,7 @@ namespace Bud
         {
             while(true)
             {
+                //todo, limit this to run at a max of... 10 fps? instead of just spinning
                 Context.CURRENT_SCREEN.render();
                 Context.CURRENT_SCREEN.processInput(Console.ReadKey());
             }

--- a/Bud/Screens/MainScreen.cs
+++ b/Bud/Screens/MainScreen.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Bud.Modules;
 
 namespace Bud.Screens
 {
@@ -15,7 +16,7 @@ namespace Bud.Screens
         public MainScreen()
         {
             menu = new MenuList();
-            optionList = new List<string>() { "Option 1", "Option 2", "Option 3" };
+            optionList = new List<string>() { "Navigator", "Option 2", "Option 3" };
             menu.addOptionList(optionList);
         }
 
@@ -32,11 +33,28 @@ namespace Bud.Screens
             switch (input.Key)
             {
                 case ConsoleKey.Enter:
+                    processOption(menu);
                     break;
                 default:
                     menu.processInput(input);
                     break;
             }
+        }
+
+        private void processOption(MenuList menuList)
+        {
+            string selectionOption = menuList.getSelectedOption();
+            switch (selectionOption)
+            {
+                case "Navigator":
+                    Module navigator = new Modules.Navigator.NavigatorModule();
+                    Context.loadModule(navigator);
+                    break;
+            }
+        }
+
+        public void cleanup()
+        {
         }
     }
 }

--- a/Bud/Screens/Screen.cs
+++ b/Bud/Screens/Screen.cs
@@ -10,6 +10,6 @@ namespace Bud.Screens
     {
         void render();
         void processInput(ConsoleKeyInfo input);
-
+        void cleanup();
     }
 }

--- a/Bud/Widgets/MenuList.cs
+++ b/Bud/Widgets/MenuList.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 
 namespace Bud.Widgets
 {
+    //Has a number of runtime configurable options which can be cycled through and selected.
+    //The actual selection of an option is handled by the screen, and the selected option found through the getSelectedOption() method
     class MenuList : Widget
     {
         private List<string> items;

--- a/Bud/Widgets/Widget.cs
+++ b/Bud/Widgets/Widget.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 namespace Bud.Widgets
 {
+    //A widget is a reusable UI element which may or may not be interactable.
     interface Widget
     {
         void render();


### PR DESCRIPTION
Context:
-Error() added to context
-Screenstack added to maintain screen history
-modules can be loaded
-transition() added to transition to different screen
-backScreen() added to move back to previous screen

Module interface:
-init() for initialization
-getScreen() provides the main screen of the module
-render() renders the current module screen if need be. - May remove

NavigatorModule:
-navigator module introduced
-intended to eventually be used as a file explorer
-comes with a basic menu list and pressing B returns to previous screen

Various comments added
